### PR TITLE
Add upload date override

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -501,8 +501,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -924,6 +926,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "erabooru-file-watcher"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "mime_guess",
  "notify",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 once_cell = "1.21.3"
 tauri-plugin-store = "2"
 walkdir = "2"
+chrono = "0.4"
 
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -14,6 +14,7 @@ pub fn save_settings(
     folder: String,
     server: String,
     auto_tags: Vec<utils::store::AutoTagRule>,
+    override_upload_date: bool,
 ) -> Result<(), String> {
     println!("Saving settings: folder = {}, server = {}", folder, server);
 
@@ -22,6 +23,7 @@ pub fn save_settings(
         folder,
         server,
         auto_tags,
+        override_upload_date,
     };
 
     store.set(

--- a/src-tauri/src/utils/erabooru.rs
+++ b/src-tauri/src/utils/erabooru.rs
@@ -1,6 +1,6 @@
 use xxhash_rust::xxh3::xxh3_128;
 use reqwest::blocking::Client;
-use std::path::Path;
+use std::{path::Path, thread, time::Duration};
 
 use crate::utils::{files, tagging, store::AutoTagRule};
 
@@ -124,6 +124,18 @@ pub fn apply_tags_and_date(
     auto_tags: &[AutoTagRule],
     override_upload_date: bool,
 ) {
+    // Wait for the media to be indexed before applying tags and dates
+    if let Err(e) = wait_for_media_indexing(
+        client, 
+        server, 
+        id, 
+        10, // max attempts
+        Duration::from_millis(500) // delay between attempts
+    ) {
+        println!("Failed to wait for media indexing for {}: {}", path.display(), e);
+        return;
+    }
+    
     let tags = tagging::tags_for_path(path, auto_tags);
     if !tags.is_empty() {
         let tag_refs: Vec<&str> = tags.iter().map(|t| t.as_str()).collect();
@@ -139,4 +151,60 @@ pub fn apply_tags_and_date(
             }
         }
     }
+}
+
+pub fn check_media_exists(
+    client: &Client,
+    server: &str,
+    id: &str,
+) -> Result<bool, String> {
+    let url = format!("{}/api/media/{}", server.trim_end_matches('/'), id);
+    
+    let resp = client
+        .get(&url)
+        .send()
+        .map_err(|e| format!("Failed to check media existence: {}", e))?;
+    
+    match resp.status().as_u16() {
+        200 => Ok(true),
+        404 => Ok(false),
+        status => Err(format!("Unexpected status when checking media: {}", status)),
+    }
+}
+
+pub fn wait_for_media_indexing(
+    client: &Client,
+    server: &str,
+    id: &str,
+    max_attempts: u32,
+    delay: Duration,
+) -> Result<(), String> {
+    println!("Waiting for media {} to be indexed...", id);
+    
+    for attempt in 1..=max_attempts {
+        match check_media_exists(client, server, id) {
+            Ok(true) => {
+                println!("Media {} is now available (attempt {})", id, attempt);
+                return Ok(());
+            }
+            Ok(false) => {
+                if attempt < max_attempts {
+                    println!("Media {} not yet available, waiting... (attempt {}/{})", id, attempt, max_attempts);
+                    thread::sleep(delay);
+                } else {
+                    return Err(format!("Media {} was not indexed after {} attempts", id, max_attempts));
+                }
+            }
+            Err(e) => {
+                println!("Error checking media existence: {}", e);
+                if attempt < max_attempts {
+                    thread::sleep(delay);
+                } else {
+                    return Err(format!("Failed to verify media indexing: {}", e));
+                }
+            }
+        }
+    }
+    
+    Ok(())
 }

--- a/src-tauri/src/utils/files.rs
+++ b/src-tauri/src/utils/files.rs
@@ -50,5 +50,6 @@ pub fn file_modified_utc(path: &Path) -> Result<String, String> {
     let metadata = std::fs::metadata(path).map_err(|e| e.to_string())?;
     let modified = metadata.modified().map_err(|e| e.to_string())?;
     let datetime: chrono::DateTime<chrono::Utc> = modified.into();
-    Ok(datetime.to_rfc3339())
+    let formatted: String = datetime.format("%Y-%m-%d").to_string();
+    Ok(formatted)
 }

--- a/src-tauri/src/utils/files.rs
+++ b/src-tauri/src/utils/files.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use mime_guess::MimeGuess;
+use chrono::prelude::*;
 
 pub fn is_media_file(path: &Path) -> bool {
     if !path.is_file() {
@@ -43,4 +44,11 @@ pub fn retry_read_file(
         }
     }
     Err("File remained locked after all retry attempts".to_string())
+}
+
+pub fn file_modified_utc(path: &Path) -> Result<String, String> {
+    let metadata = std::fs::metadata(path).map_err(|e| e.to_string())?;
+    let modified = metadata.modified().map_err(|e| e.to_string())?;
+    let datetime: chrono::DateTime<chrono::Utc> = modified.into();
+    Ok(datetime.to_rfc3339())
 }

--- a/src-tauri/src/utils/store.rs
+++ b/src-tauri/src/utils/store.rs
@@ -14,6 +14,8 @@ pub struct Settings {
     pub server: String,
     #[serde(default)]
     pub auto_tags: Vec<AutoTagRule>,
+    #[serde(default)]
+    pub override_upload_date: bool,
 }
 
 pub fn get_settings(app: &tauri::AppHandle) -> Result<Settings, String> {

--- a/src/lib/SettingsTab.svelte
+++ b/src/lib/SettingsTab.svelte
@@ -8,17 +8,20 @@
   }
 
   let pairs = $state<Pair[]>([]);
+  let overrideUploadDate = $state(false);
 
   async function loadPairs() {
     const store = await load('store.json');
     const settings = await store.get<any>('settings');
     pairs = settings?.auto_tags ?? [];
+    overrideUploadDate = settings?.override_upload_date ?? false;
   }
 
   async function savePairs() {
     const store = await load('store.json');
     const settings = await store.get<any>('settings') ?? {};
     settings.auto_tags = pairs;
+    settings.override_upload_date = overrideUploadDate;
     await store.set('settings', settings);
     await store.save();
   }
@@ -35,6 +38,10 @@
 </script>
 
 <div class="p-4 space-y-4">
+  <div class="flex items-center gap-2">
+    <input type="checkbox" bind:checked={overrideUploadDate} id="override-date" />
+    <label for="override-date" class="text-sm">Override upload date with system date</label>
+  </div>
   <div class="space-y-2">
     {#each pairs as pair, i}
       <div class="flex gap-2 items-center">

--- a/src/lib/SettingsTab.svelte
+++ b/src/lib/SettingsTab.svelte
@@ -9,12 +9,22 @@
 
   let pairs = $state<Pair[]>([]);
   let overrideUploadDate = $state(false);
+  let loaded = false;
 
   async function loadPairs() {
     const store = await load('store.json');
     const settings = await store.get<any>('settings');
     pairs = settings?.auto_tags ?? [];
     overrideUploadDate = settings?.override_upload_date ?? false;
+    loaded = true;
+  }
+
+  async function saveOverride(value: boolean) {
+    const store = await load('store.json');
+    const settings = (await store.get<any>('settings')) ?? {};
+    settings.override_upload_date = value;
+    await store.set('settings', settings);
+    await store.save();
   }
 
   async function savePairs() {
@@ -35,6 +45,12 @@
   }
 
   onMount(loadPairs);
+
+  $effect(() => {
+    if (loaded) {
+      saveOverride(overrideUploadDate);
+    }
+  });
 </script>
 
 <div class="p-4 space-y-4">


### PR DESCRIPTION
## Summary
- allow overriding upload date with system date in settings
- store override flag in persistent settings
- record file modification date after uploads and watching events
- add chrono dependency for time handling
- factor out common tagging/date logic

## Testing
- `npm run check`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a91ea0e248320b9c126f04aeb512b